### PR TITLE
Add 'About Records' documentation in English and Swedish

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2022-2024 KTH Royal Institute of Technology.
+Copyright (C) 2022-2025 KTH Royal Institute of Technology.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/en/communities/about_communities.md
+++ b/docs/en/communities/about_communities.md
@@ -1,0 +1,3 @@
+# About Communties
+
+# TODO

--- a/docs/en/deposit/about_records.md
+++ b/docs/en/deposit/about_records.md
@@ -31,7 +31,7 @@ You can also share research objects that already have a DOI (e.g., a journal pub
 
 ## Life Cycle
 
-A record starts as a draft, where you can fill in the metadata and upload files. Once the draft is complete, you publish the draft, and it becomes a record. Once the record is published:
+A record starts as a draft, where you can fill in the metadata and upload files. Once the draft is complete, you submit it for review to a community as a record. Once the record is published:
 
 - **Metadata CAN be modified**
 - **Files and the persistent identifier CANNOT be modified**
@@ -42,7 +42,7 @@ This is because the KTH Datarepository is a digital repository and operates acco
 
 Our versioning feature helps with cases where you need to publish an update to a dataset (i.e., modify the files). In this case, you can create a new version of your dataset.
 
-Technically, this is a completely new record with separate metadata, files, and a persistent identifier. This ensures that if a researcher cites a specific version, they can be sure the files did not change.
+Technically, this is a completely new record with separate metadata, files, and a new persistent identifier. This ensures that if a researcher cites a specific version, they can be sure the files did not change.
 
 ## Access
 

--- a/docs/en/deposit/about_records.md
+++ b/docs/en/deposit/about_records.md
@@ -50,4 +50,4 @@ Metadata for all public records in the KTH Datarepository are always publicly ac
 
 The reason we support restricted access is for cases such as embargoed content, content under peer review, content that cannot be made generally available (e.g., anonymized clinical trial data), etc.
 
-See [Collaborate and Share](#) and [Communities](#) for further options on sharing restricted content.
+See [Collaborate and Share](../share/about_share.md) and [Communities](../communities/about_communities.md) for further options on sharing restricted content.

--- a/docs/en/deposit/about_records.md
+++ b/docs/en/deposit/about_records.md
@@ -1,0 +1,53 @@
+# About Records
+
+Records are the basic entities used to share and preserve a digital research object (datasets, publications, software, posters, presentations, etc.) on the KTH Datarepository. Any user on the KTH Datarepository can create a new record. When you share and preserve research on the KTH Datarepository, you do so by creating a new record.
+
+A record consists of:
+
+- **Metadata**: Information about the title, publication date, creators, description, etc.
+- **Files**: The actual data for the digital research object.
+- **Persistent Identifier**: A globally unique persistent identifier (in our case, a Digital Object Identifier) used for the identification of the record.
+
+## Metadata
+
+The metadata is critical for describing your dataset and making your record findable. We only require minimal metadata (what's needed for a citation), but we strongly encourage entering as many fields as possible.
+
+The KTH Datarepository is able to export the metadata according to many different standards.
+
+## Files
+
+The KTH Datarepository supports uploading files of any size and format. However, you should consider uploading files in a preservation-friendly format, as we only guarantee bit-level preservation—e.g., proprietary file formats may not be readable in 10 or 50 years.
+
+For further guidance on preservation-friendly formats, please see the following resources:
+
+- [Digital Preservation Handbook - File formats and standards](https://www.dpconline.org/handbook)
+- [Library of Congress recommended format specifications](https://www.loc.gov/preservation/resources/rfs/)
+
+## Persistent Identifier
+
+The KTH Datarepository will automatically register a Digital Object Identifier (DOI) for a record once you publish it. The DOI is a globally unique persistent identifier that ensures the record can be uniquely cited, which is important for reproducibility and attribution of credit. The KTH Datarepository registers DOIs with DataCite.
+
+You can also share research objects that already have a DOI (e.g., a journal publication) on the KTH Datarepository. In this case, you must provide the DOI during the upload to the KTH Datarepository so that we don't create a new DOI for your content.
+
+## Life Cycle
+
+A record starts as a draft, where you can fill in the metadata and upload files. Once the draft is complete, you publish the draft, and it becomes a record. Once the record is published:
+
+- **Metadata CAN be modified**
+- **Files and the persistent identifier CANNOT be modified**
+
+This is because the KTH Datarepository is a digital repository and operates according to best practices for archiving. A researcher citing a specific dataset on the KTH Datarepository must be able to rely on the fact that the dataset they used is not modified, as it could potentially invalidate their findings or make them impossible to reproduce.
+
+## Versions
+
+Our versioning feature helps with cases where you need to publish an update to a dataset (i.e., modify the files). In this case, you can create a new version of your dataset.
+
+Technically, this is a completely new record with separate metadata, files, and a persistent identifier. This ensures that if a researcher cites a specific version, they can be sure the files did not change.
+
+## Access
+
+Metadata for all public records in the KTH Datarepository are always publicly accessible. You have the possibility to restrict access to the files, and once you restrict access, you can share with specific people.
+
+The reason we support restricted access is for cases such as embargoed content, content under peer review, content that cannot be made generally available (e.g., anonymized clinical trial data), etc.
+
+See [Collaborate and Share](#) and [Communities](#) for further options on sharing restricted content.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -25,7 +25,7 @@
 
 - ## Collaborate and share
 
-    - [About collaboration and sharing (WIP)](#)
+    - [About collaboration and sharing](share/about_share.md)
     - [User sharing (WIP)](#)
     - [Link sharing (WIP)](#)
     - [Access requests (WIP)](#)
@@ -36,7 +36,7 @@
 
 - ## Communities
 
-    - [About communities (WIP)](#)
+    - [About communities](communities/about_communities.md)
     - [Community manager responsibilities](communities/community_manager_responsibilities.md)
     - [Apply for a new community](communities/apply_new_community.md)
     - [View my communities (WIP)](#)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -12,7 +12,7 @@
 
 - ## Deposit
 
-    - [About records (WIP)](#)
+    - [About records](deposit/about_records.md)
     - [Create new upload](deposit/create_new_upload.md)
     - [Describe records (WIP)](#)
     - [Manage files (WIP)](#)

--- a/docs/en/share/about_share.md
+++ b/docs/en/share/about_share.md
@@ -1,0 +1,3 @@
+# About Share
+
+# TODO

--- a/docs/en/share/about_share.md
+++ b/docs/en/share/about_share.md
@@ -1,3 +1,3 @@
 # About Share
 
-# TODO
+## Work in progress

--- a/docs/sv/communities/about_communities.md
+++ b/docs/sv/communities/about_communities.md
@@ -1,0 +1,3 @@
+# Om Communties
+
+# TODO

--- a/docs/sv/communities/about_communities.md
+++ b/docs/sv/communities/about_communities.md
@@ -1,3 +1,3 @@
 # Om Communties
 
-# TODO
+## Work in progress

--- a/docs/sv/deposit/about_records.md
+++ b/docs/sv/deposit/about_records.md
@@ -1,0 +1,53 @@
+# Om poster
+
+Poster är de grundläggande enheterna som används för att dela och bevara ett digitalt forskningsobjekt (datamängder, publikationer, programvara, affischer, presentationer, etc.) på KTH Datarepository. Alla användare på KTH Datarepository kan skapa en ny post. När du delar och bevarar forskning på KTH Datarepository gör du det genom att skapa en ny post.
+
+En post består av:
+
+- **Metadata**: Information om titel, publiceringsdatum, skapare, beskrivning, etc.
+- **Filer**: De faktiska data för det digitala forskningsobjektet.
+- **Beständig identifierare**: En globalt unik beständig identifierare (i vårt fall en Digital Object Identifier) som används för att identifiera posten.
+
+## Metadata
+
+Metadata är avgörande för att beskriva din datamängd och göra din post sökbar. Vi kräver endast minimal metadata (vad som behövs för en citering), men vi uppmuntrar starkt att fylla i så många fält som möjligt.
+
+KTH Datarepository kan exportera metadata enligt många olika standarder.
+
+## Filer
+
+KTH Datarepository stöder uppladdning av filer i valfri storlek och format. Du bör dock överväga att ladda upp filer i ett bevarandevänligt format, eftersom vi endast garanterar bitnivåbevarande—t.ex. kan proprietära filformat inte vara läsbara om 10 eller 50 år.
+
+För ytterligare vägledning om bevarandevänliga format, se följande resurser:
+
+- [Digital Preservation Handbook - File formats and standards](https://www.dpconline.org/handbook)
+- [Library of Congress recommended format specifications](https://www.loc.gov/preservation/resources/rfs/)
+
+## Beständig identifierare
+
+KTH Datarepository registrerar automatiskt en Digital Object Identifier (DOI) för en post när du publicerar den. DOI är en globalt unik beständig identifierare som säkerställer att posten kan citeras unikt, vilket är viktigt för reproducerbarhet och tilldelning av erkännande. KTH Datarepository registrerar DOI med DataCite.
+
+Du kan också dela forskningsobjekt som redan har en DOI (t.ex. en tidskriftspublicering) på KTH Datarepository. I detta fall måste du ange DOI under uppladdningen till KTH Datarepository så att vi inte skapar en ny DOI för ditt innehåll.
+
+## Livscykel
+
+En post börjar som ett utkast, där du kan fylla i metadata och ladda upp filer. När utkastet är klart publicerar du det, och det blir en post. När posten är publicerad:
+
+- **Metadata KAN ändras**
+- **Filer och den beständiga identifieraren KAN INTE ändras**
+
+Detta beror på att KTH Datarepository är ett digitalt arkiv och följer bästa praxis för arkivering. En forskare som citerar en specifik datamängd på KTH Datarepository måste kunna lita på att datamängden de använde inte har ändrats, eftersom det potentiellt kan ogiltigförklara deras resultat eller göra dem omöjliga att reproducera.
+
+## Versioner
+
+Vår versionshanteringsfunktion hjälper till när du behöver publicera en uppdatering av en datamängd (dvs. ändra filerna). I detta fall kan du skapa en ny version av din datamängd.
+
+Tekniskt sett är detta en helt ny post med separat metadata, filer och en beständig identifierare. Detta säkerställer att om en forskare citerar en specifik version kan de vara säkra på att filerna inte har ändrats.
+
+## Åtkomst
+
+Metadata för alla publik poster i KTH Datarepository är alltid offentligt tillgängliga. Du har möjlighet att begränsa åtkomsten till filerna, och när du begränsar åtkomsten kan du dela med specifika personer.
+
+Anledningen till att vi stöder begränsad åtkomst är för fall som embargoinnehåll, innehåll under peer review, innehåll som inte kan göras allmänt tillgängligt (t.ex. anonymiserade kliniska prövningsdata), etc.
+
+Se [Samarbeta och dela](#) och [Communities](#) för fler alternativ på att dela begränsat innehåll.

--- a/docs/sv/deposit/about_records.md
+++ b/docs/sv/deposit/about_records.md
@@ -1,52 +1,52 @@
 # Om poster
 
-Poster är de grundläggande enheterna som används för att dela och bevara ett digitalt forskningsobjekt (datamängder, publikationer, programvara, affischer, presentationer, etc.) på KTH Datarepository. Alla användare på KTH Datarepository kan skapa en ny post. När du delar och bevarar forskning på KTH Datarepository gör du det genom att skapa en ny post.
+Poster är de grundläggande enheterna som används för att dela och bevara ett digitalt forskningsobjekt (dataset, publikationer, programvara, affischer, presentationer, etc.) på KTH Data Repository. Alla användare på KTH Data Repository kan skapa en ny post. När du delar och bevarar forskning på KTH Data Repository gör du det genom att skapa en ny post.
 
 En post består av:
 
 - **Metadata**: Information om titel, publiceringsdatum, skapare, beskrivning, etc.
-- **Filer**: De faktiska data för det digitala forskningsobjektet.
-- **Beständig identifierare**: En globalt unik beständig identifierare (i vårt fall en Digital Object Identifier) som används för att identifiera posten.
+- **Filer**: Den faktiska datan för det digitala forskningsobjektet.
+- **Persistent identifierare**: En globalt unik persistent identifierare (i vårt fall en Digital Object Identifier) som används för att identifiera posten.
 
 ## Metadata
 
-Metadata är avgörande för att beskriva din datamängd och göra din post sökbar. Vi kräver endast minimal metadata (vad som behövs för en citering), men vi uppmuntrar starkt att fylla i så många fält som möjligt.
+Metadata är avgörande för att beskriva ditt dataset och göra din post sökbar. Vi kräver endast minimal metadata (vad som behövs för en citering), men vi uppmuntrar starkt att fylla i så många fält som möjligt.
 
-KTH Datarepository kan exportera metadata enligt många olika standarder.
+KTH Data Repository kan exportera metadata enligt många olika standarder.
 
 ## Filer
 
-KTH Datarepository stöder uppladdning av filer i valfri storlek och format. Du bör dock överväga att ladda upp filer i ett bevarandevänligt format, eftersom vi endast garanterar bitnivåbevarande—t.ex. kan proprietära filformat inte vara läsbara om 10 eller 50 år.
+KTH Data Repository stöder uppladdning av filer i valfri storlek och format. Du bör dock överväga att ladda upp filer i ett bevarandevänligt format, eftersom vi endast garanterar bitnivåbevarande — t.ex. kan proprietära filformat inte vara läsbara om 10 eller 50 år.
 
 För ytterligare vägledning om bevarandevänliga format, se följande resurser:
 
 - [Digital Preservation Handbook - File formats and standards](https://www.dpconline.org/handbook)
 - [Library of Congress recommended format specifications](https://www.loc.gov/preservation/resources/rfs/)
 
-## Beständig identifierare
+## Persistent identifierare
 
-KTH Datarepository registrerar automatiskt en Digital Object Identifier (DOI) för en post när du publicerar den. DOI är en globalt unik beständig identifierare som säkerställer att posten kan citeras unikt, vilket är viktigt för reproducerbarhet och tilldelning av erkännande. KTH Datarepository registrerar DOI med DataCite.
+KTH Data Repository registrerar automatiskt en Digital Object Identifier (DOI) för en post när du publicerar den. DOI är en globalt unik persistent identifierare som säkerställer att posten kan citeras unikt, vilket är viktigt för reproducerbarhet och erkännande av upphovsersonerna. KTH Data Repository registrerar DOI:er med DataCite.
 
-Du kan också dela forskningsobjekt som redan har en DOI (t.ex. en tidskriftspublicering) på KTH Datarepository. I detta fall måste du ange DOI under uppladdningen till KTH Datarepository så att vi inte skapar en ny DOI för ditt innehåll.
+Du kan också dela forskningsobjekt som redan har en DOI (t.ex. en tidskriftspublicering) på KTH Data Repository. I detta fall måste du ange DOI under uppladdningen till KTH Data Repository så att vi inte skapar en ny DOI för ditt innehåll.
 
 ## Livscykel
 
-En post börjar som ett utkast, där du kan fylla i metadata och ladda upp filer. När utkastet är klart publicerar du det, och det blir en post. När posten är publicerad:
+En post börjar som ett utkast, där du kan fylla i metadata och ladda upp filer. När utkastet är klart skickar du det för granskning av en community som en post. När posten är publicerad:
 
-- **Metadata KAN ändras**
-- **Filer och den beständiga identifieraren KAN INTE ändras**
+- **KAN Metadata ändras**
+- **Filer och den persistenta identifieraren KAN INTE ändras**
 
-Detta beror på att KTH Datarepository är ett digitalt arkiv och följer bästa praxis för arkivering. En forskare som citerar en specifik datamängd på KTH Datarepository måste kunna lita på att datamängden de använde inte har ändrats, eftersom det potentiellt kan ogiltigförklara deras resultat eller göra dem omöjliga att reproducera.
+Detta beror på att KTH Data Repository är ett digitalt arkiv och följer bästa praxis för arkivering. En forskare som citerar en specifik datamängd på KTH Data Repository måste kunna lita på att datamängden de använde inte har ändrats, eftersom det potentiellt kan ogiltigförklara deras resultat eller göra dem omöjliga att reproducera.
 
 ## Versioner
 
-Vår versionshanteringsfunktion hjälper till när du behöver publicera en uppdatering av en datamängd (dvs. ändra filerna). I detta fall kan du skapa en ny version av din datamängd.
+Vår versionshanteringsfunktion hjälper till när du behöver publicera en uppdatering av ett dataset eller en datamängd (dvs. ändra filerna). I detta fall kan du skapa en ny version av ditt dataset.
 
-Tekniskt sett är detta en helt ny post med separat metadata, filer och en beständig identifierare. Detta säkerställer att om en forskare citerar en specifik version kan de vara säkra på att filerna inte har ändrats.
+Tekniskt sett är detta en helt ny post med separat metadata, filer och en ny persistent identifierare. Detta säkerställer att om en forskare citerar en specifik version kan de vara säkra på att filerna inte har ändrats.
 
 ## Åtkomst
 
-Metadata för alla publik poster i KTH Datarepository är alltid offentligt tillgängliga. Du har möjlighet att begränsa åtkomsten till filerna, och när du begränsar åtkomsten kan du dela med specifika personer.
+Metadata för alla publika poster i KTH Data Repository är alltid offentligt tillgängliga. Du har möjlighet att begränsa åtkomsten till filerna, och när du begränsar åtkomsten kan du dela med specifika personer.
 
 Anledningen till att vi stöder begränsad åtkomst är för fall som embargoinnehåll, innehåll under peer review, innehåll som inte kan göras allmänt tillgängligt (t.ex. anonymiserade kliniska prövningsdata), etc.
 

--- a/docs/sv/deposit/about_records.md
+++ b/docs/sv/deposit/about_records.md
@@ -50,4 +50,4 @@ Metadata för alla publik poster i KTH Datarepository är alltid offentligt till
 
 Anledningen till att vi stöder begränsad åtkomst är för fall som embargoinnehåll, innehåll under peer review, innehåll som inte kan göras allmänt tillgängligt (t.ex. anonymiserade kliniska prövningsdata), etc.
 
-Se [Samarbeta och dela](#) och [Communities](#) för fler alternativ på att dela begränsat innehåll.
+Se [Samarbeta och dela](../share/about_share.md) och [Communities](../communities/about_communities.md) för fler alternativ på att dela begränsat innehåll.

--- a/docs/sv/index.md
+++ b/docs/sv/index.md
@@ -12,7 +12,7 @@
 
 - ## Insättning
 
-    - [Om poster (WIP)](#)
+    - [Om poster](deposit/about_records.md)
     - [Skapa ny uppladdning](deposit/create_new_upload.md)
     - [Beskriv poster (WIP)](#)
     - [Hantera filer (WIP)](#)

--- a/docs/sv/index.md
+++ b/docs/sv/index.md
@@ -25,7 +25,7 @@
 
 - ## Samarbeta och dela
 
-    - [Om samarbete och delning (WIP)](#)
+    - [Om samarbete och delning](share/about_share.md)
     - [Användardelning (WIP)](#)
     - [Länkdelning (WIP)](#)
     - [Åtkomstförfrågningar (WIP)](#)
@@ -36,7 +36,7 @@
 
 - ## Communities
 
-    - [Om communities (WIP)](#)
+    - [Om communities](communities/about_communities.md)
     - [Community manager-ansvar](communities/community_manager_responsibilities.md)
     - [Ansök om en ny community](communities/apply_new_community.md)
     - [Visa mina communities (WIP)](#)

--- a/docs/sv/index.md
+++ b/docs/sv/index.md
@@ -10,7 +10,7 @@
     - [Logga in och logga ut](get_started/login_logout.md)
     - [Navigera i KTH Data Repository](get_started/navigating_site.md)
 
-- ## Insättning
+- ## Deponering
 
     - [Om poster](deposit/about_records.md)
     - [Skapa ny uppladdning](deposit/create_new_upload.md)

--- a/docs/sv/share/about_share.md
+++ b/docs/sv/share/about_share.md
@@ -1,3 +1,3 @@
 # Om samarbete och delning
 
-# TODO
+## Work in progress

--- a/docs/sv/share/about_share.md
+++ b/docs/sv/share/about_share.md
@@ -1,0 +1,3 @@
+# Om samarbete och delning
+
+# TODO

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ plugins:
                 - Visa inloggade enheter: get_started/viewing-devices.md
                 - Navigera i KTH Data Repository: get_started/navigating_site.md
             - Deponera data:
+                - Om poster: deposit/about_records.md
                 - Skapa ny uppladdning: deposit/create_new_upload.md
                 - Begränsade Poster: deposit/restrict_record_access.md
                 - Dela poståtkomst: deposit/share_record_access.md
@@ -112,6 +113,7 @@ nav:
       - View Logged in Devices: get_started/viewing-devices.md
       - Navigating the KTH Data Repository: get_started/navigating_site.md
   - Deposit:
+      - About Records: deposit/about_records.md
       - Create New Upload: deposit/create_new_upload.md
       - Restricted Records: deposit/restrict_record_access.md
       - Share Record Access: deposit/share_record_access.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: KTH Data Repository Guides
 site_url: https://kth-library.github.io/docs-kth-rdm/
 repo_url: https://github.com/KTH-Library/docs-kth-rdm
-copyright: '© 2024 KTH Royal Institute of Technology'
+copyright: '© 2025 KTH Royal Institute of Technology'
 
 extra_css:
   - stylesheets/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,8 +96,11 @@ plugins:
                 - Github Integration: deposit/github_integration.md
                 - REST API: deposit/rest_api.md
             - Communities:
+                - Om Communities: communities/about_communities.md
                 - Ansök om Nytt Community: communities/apply_new_community.md
                 - Community manager-ansvar: communities/community_manager_responsibilities.md
+            - Samarbeta och dela:
+                - Samarbeta och dela: share/about_share.md
             - Om:
                 - Villkor för användning: terms.md
                 - Cookies Policy: cookie-policy.md
@@ -120,8 +123,11 @@ nav:
       - Github Integration: deposit/github_integration.md
       - REST API: deposit/rest_api.md
   - Communities:
+      - About Communities: communities/about_communities.md
       - Apply for New Community: communities/apply_new_community.md
       - Community Manager Responsibilities: communities/community_manager_responsibilities.md
+  - Collaborate and share:
+      - Collaborate and share : share/about_share.md
   - About:
       - Terms of Use: terms.md
       - Cookies Policy: cookie-policy.md


### PR DESCRIPTION
Update the copyright year in the MkDocs configuration and introduce comprehensive documentation on 'About Records' in both English and Swedish, enhancing user guidance on record creation and management in the KTH Datarepository.