### PR TITLE
Add documentation for describing records and DOI details

### DIFF
--- a/docs/en/deposit/describe_records.md
+++ b/docs/en/deposit/describe_records.md
@@ -4,8 +4,8 @@ See the [Create new upload](./create_new_upload.md) for an overview of creating 
 
 - **[Resource types](#resource-types)** — Select the right resource type.
 - **[Digital Object Identifier (DOI)](#digital-object-identifier-doi)** — How to reserve a DOI for inclusion in files before publication.
-- **Titles** — How to add a main title and additional titles.
-- **Publication date** — Learn to use date ranges or imprecise dates.
+- **[Titles](#titles)** — How to add a main title and additional titles.
+- **[Publication date](#publication-date)** — Learn to use date ranges or imprecise dates.
 - **Creators** — Learn how to add creators/authors for your post.
 - **Descriptions** — Learn how to add abstracts and notes.
 - **Licenses and rights** — Learn to choose a license for your post.
@@ -52,3 +52,30 @@ If you have already shared or uploaded your post to another repository or journa
 
 1. In the **Digital Object Identifier** field, answer **"Yes"** to the question *"Do you already have a DOI for this upload?"*
 2. Copy and paste (to avoid typos) the existing DOI into the field. The DOI will be validated for conformity, and a given DOI may only be deposited once in the KTH Data Repository (i.e., duplicate detection is in place).
+
+## Titles
+
+The title field is a required field in the deposit form. The title is essential for readers to discover your research, and it is used in citations and when posts are displayed anywhere in the repository.
+
+You may optionally add additional titles, such as subtitles, translated titles, or alternative titles.
+
+## Add an additional title
+
+1. Click the **Add titles** button.
+2. Provide the additional title and select the title type (*alternative title, subtitle, translated title, or other*).
+3. Optionally, set the language of the additional title.
+
+## Publication date
+
+The **publication date** field is a required field. By default, it is set to the date the draft was created. If your upload was previously published elsewhere (e.g., as a journal article), please use the date of the first publication.
+
+Note that in addition to the publication date, the KTH Data Repository keeps track of the date a post was uploaded to the repository.
+
+## Imprecise dates (EDTF)
+
+For older content, you may not always know the precise publication date. In these cases, you can use both imprecise dates and date ranges following the **Extended Date Time Format (EDTF) Level 1** standard:
+
+1. **Reduced precision for year and month** – `2025-09` refers to the month of September 2025.
+2. **Reduced precision for year** – `2025` refers to the calendar year 2025.
+3. **Time interval** – `2025-01-01/2025-09-23` refers to the time interval beginning on January 1, 2025, and ending on September 23, 2025.
+4. **Time interval imprecise** – `1939/1945` refers to the time interval beginning sometime in 1939 and ending sometime in 1945.

--- a/docs/en/deposit/describe_records.md
+++ b/docs/en/deposit/describe_records.md
@@ -3,7 +3,7 @@
 See the [Create new upload](./create_new_upload.md) for an overview of creating a new upload. This section provides a detailed description of each field available in the deposit form:
 
 - **[Resource types](#resource-types)** — Select the right resource type.
-- **Digital Object Identifier (DOI)** — How to reserve a DOI for inclusion in files before publication.
+- **[Digital Object Identifier (DOI)](#digital-object-identifier-doi)** — How to reserve a DOI for inclusion in files before publication.
 - **Titles** — How to add a main title and additional titles.
 - **Publication date** — Learn to use date ranges or imprecise dates.
 - **Creators** — Learn how to add creators/authors for your post.
@@ -26,3 +26,29 @@ You may find that you want to share a digital object that consists of, for examp
 
 1. **Choose one type** – Select the resource type that you believe best describes and/or is most significant for the upload. For instance, the main contribution may be the dataset, while the software consists of a couple of processing scripts.
 2. **Split the upload** – Divide the upload into multiple posts, one per resource type. Choose this method when both, for example, the dataset and software are significant contributions in themselves.
+
+## Digital Object Identifier (DOI)
+
+A Digital Object Identifier (DOI) is a globally unique persistent identifier for your post. The DOI is important because:
+
+- It provides a permanent link to your upload so readers can always reliably locate your content.
+- It is important for discovery systems to attribute citations correctly.
+- It enables reliable interlinking of research outputs.
+- It makes your research more discoverable by indexing the DOI metadata in a global registry.
+
+By default, the KTH Data Repository registers DOIs for all uploads when they are published. If you need to know the DOI before publication, you can use the method below to reserve a DOI. The reserved DOI can then be included in files (e.g., a text document) before uploading them.
+
+## Reserve a DOI
+
+1. In the **Digital Object Identifier** field, answer **"No"** to the question *"Do you already have a DOI for this upload?"*
+2. Click the **Get a DOI now!** button.
+3. A DOI will now be reserved for you. You can include this DOI in files before uploading them (e.g., in a text document). You can also remove it by clicking the **X** button next to the DOI.
+
+If you remove the reserved DOI, you can retrieve the same reserved DOI again by clicking the **Get DOI** button. However, if you delete the draft upload, the reserved DOI is lost.
+
+## Use an existing DOI
+
+If you have already shared or uploaded your post to another repository or journal, you may already have a DOI. In this case, you must provide the existing DOI to prevent multiple DOIs being registered for the same content. Note that if you are sharing supplementary data for a journal article, you should **not** use the journal article DOI.
+
+1. In the **Digital Object Identifier** field, answer **"Yes"** to the question *"Do you already have a DOI for this upload?"*
+2. Copy and paste (to avoid typos) the existing DOI into the field. The DOI will be validated for conformity, and a given DOI may only be deposited once in the KTH Data Repository (i.e., duplicate detection is in place).

--- a/docs/en/deposit/describe_records.md
+++ b/docs/en/deposit/describe_records.md
@@ -1,0 +1,28 @@
+# Describe posts
+
+See the [Create new upload](./create_new_upload.md) for an overview of creating a new upload. This section provides a detailed description of each field available in the deposit form:
+
+- **[Resource types](#resource-types)** — Select the right resource type.
+- **Digital Object Identifier (DOI)** — How to reserve a DOI for inclusion in files before publication.
+- **Titles** — How to add a main title and additional titles.
+- **Publication date** — Learn to use date ranges or imprecise dates.
+- **Creators** — Learn how to add creators/authors for your post.
+- **Descriptions** — Learn how to add abstracts and notes.
+- **Licenses and rights** — Learn to choose a license for your post.
+- **Contributors** — Learn to add persons/organisations that do not appear in the citation.
+
+## Resource types
+
+The resource type field is a required field in the deposit form. The resource type is used to describe the nature of the files being shared and is important for the discoverability of your post.
+
+## Selecting a resource type
+
+1. From the resource type field drop-down, select one of the resource types that best describes the files you are sharing.
+2. The selected resource type is important for the discoverability of your upload, both for users to find your research output and because various discovery systems only index, for example, publications, datasets, or software from the KTH Data Repository.
+
+## Mixed resource types
+
+You may find that you want to share a digital object that consists of, for example, both data and software, or any other combination of multiple resource types. In these cases, there are two possible solutions:
+
+1. **Choose one type** – Select the resource type that you believe best describes and/or is most significant for the upload. For instance, the main contribution may be the dataset, while the software consists of a couple of processing scripts.
+2. **Split the upload** – Divide the upload into multiple posts, one per resource type. Choose this method when both, for example, the dataset and software are significant contributions in themselves.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -14,7 +14,7 @@
 
     - [About records](deposit/about_records.md)
     - [Create new upload](deposit/create_new_upload.md)
-    - [Describe records (WIP)](#)
+    - [Describe records](deposit/describe_records.md)
     - [Manage files (WIP)](#)
     - [Restricted records](deposit/restrict_record_access.md)
     - [Share Record Access](deposit/share_record_access.md)

--- a/docs/sv/deposit/describe_records.md
+++ b/docs/sv/deposit/describe_records.md
@@ -3,7 +3,7 @@
 Se [Skapa ny uppladdning](./create_new_upload.md) för en översikt av att skapa en ny uppladdning. Denna sektion ger en detaljerad beskrivning av varje fält som finns tillgängligt i formuläret för uppladdning:
 
 - **[Resurstyper](#resurstyper)** — Välj rätt resurstyp.
-- **Digital Object Identifier (DOI)** — Hur man reserverar en DOI för inkludering i filer före publicering.
+- **[Digital Object Identifier (DOI)](#digital-object-identifier-doi)** — Hur man reserverar en DOI för inkludering i filer före publicering.
 - **Titlar** — Hur man lägger till huvudtitel och ytterligare titlar.
 - **Publiceringsdatum** — Lär dig använda datumintervall eller oprecisa datum.
 - **Skapare** — Lär dig hur man lägger till skapare/författare för ditt inlägg.
@@ -26,3 +26,29 @@ I vissa fall kan du vilja dela ett digitalt objekt som består av exempelvis bå
 
 1. **Välj en typ** – Välj den resurstyp som du anser bäst beskriver och/eller är mest betydelsefull för uppladdningen. Till exempel kan datasetet vara huvudbidraget, medan programvaran endast består av några bearbetningsskript.
 2. **Dela upp uppladdningen** – Dela upp uppladdningen i flera inlägg, ett per resurstyp. Använd denna metod när både datasetet och programvaran är betydande bidrag i sig själva.
+
+## Digital Object Identifier (DOI)
+
+En Digital Object Identifier (DOI) är en globalt unik och beständig identifierare för ditt inlägg. DOI är viktig eftersom:
+
+- Den ger en permanent länk till din uppladdning så att läsare alltid kan hitta ditt innehåll på ett tillförlitligt sätt.
+- Den är viktig för att söksystem ska kunna hänföra citeringar korrekt.
+- Den möjliggör pålitlig sammanlänkning av forskningsresultat.
+- Den gör din forskning mer sökbar genom att indexera DOI-metadatan i ett globalt register.
+
+Som standard registrerar KTH Data Repository DOIs för alla uppladdningar när de publiceras. Om du behöver känna till DOI:n innan publicering kan du använda metoden nedan för att reservera en DOI. Den reserverade DOI:n kan sedan inkluderas i filer (t.ex. ett textdokument) innan de laddas upp.
+
+## Reservera en DOI
+
+1. I fältet **Digital Object Identifier**, svara **"Nej"** på frågan *"Har du redan en DOI för denna uppladdning?"*
+2. Klicka på knappen **Få en DOI nu!**
+3. En DOI kommer nu att reserveras för dig. Du kan inkludera denna DOI i filer innan du laddar upp dem (t.ex. i ett textdokument). Du kan också ta bort den genom att klicka på **X-knappen** bredvid DOI:n.
+
+Om du tar bort den reserverade DOI:n kan du återfå samma reserverade DOI genom att klicka på **Få DOI**-knappen igen. Om du däremot raderar utkastet till uppladdningen går den reserverade DOI:n förlorad.
+
+## Använd en befintlig DOI
+
+Om du redan har delat eller laddat upp ditt inlägg i en annan databas eller tidskrift, kan du redan ha en DOI. I så fall måste du ange den befintliga DOI:n för att förhindra att flera DOI:er registreras för samma innehåll. Observera att om du delar kompletterande data till en tidskriftsartikel, bör du **inte** använda tidskriftsartikelns DOI.
+
+1. I fältet **Digital Object Identifier**, svara **"Ja"** på frågan *"Har du redan en DOI för denna uppladdning?"*
+2. Kopiera och klistra in (för att undvika skrivfel) den befintliga DOI:n i fältet. DOI:n kommer att valideras för korrekt format, och en given DOI kan endast registreras en gång i KTH Data Repository (dubbleringar upptäcks automatiskt).

--- a/docs/sv/deposit/describe_records.md
+++ b/docs/sv/deposit/describe_records.md
@@ -1,0 +1,28 @@
+# Beskriv inlägg
+
+Se [Skapa ny uppladdning](./create_new_upload.md) för en översikt av att skapa en ny uppladdning. Denna sektion ger en detaljerad beskrivning av varje fält som finns tillgängligt i formuläret för uppladdning:
+
+- **[Resurstyper](#resurstyper)** — Välj rätt resurstyp.
+- **Digital Object Identifier (DOI)** — Hur man reserverar en DOI för inkludering i filer före publicering.
+- **Titlar** — Hur man lägger till huvudtitel och ytterligare titlar.
+- **Publiceringsdatum** — Lär dig använda datumintervall eller oprecisa datum.
+- **Skapare** — Lär dig hur man lägger till skapare/författare för ditt inlägg.
+- **Beskrivningar** — Lär dig hur man lägger till sammanfattningar och anteckningar.
+- **Licenser och rättigheter** — Lär dig välja en licens för ditt inlägg.
+- **Bidragsgivare** — Lär dig lägga till personer/organisationer som inte förekommer i citeringen.
+
+## Resurstyper
+
+Fältet för resurstyp är ett obligatoriskt fält i formuläret för uppladdning. Resurstypen används för att beskriva filernas natur och är viktig för att göra ditt inlägg sökbart.
+
+## Välja en resurstyp
+
+1. Från rullgardinsmenyn för resurstyp, välj den resurstyp som bäst beskriver filerna du delar.
+2. Den valda resurstypen är viktig för att göra din uppladdning sökbar, både för användare som vill hitta ditt forskningsresultat och eftersom olika söksystem endast indexerar exempelvis publikationer, dataset eller programvara från KTH Data Repository.
+
+## Blandade resurstyper
+
+I vissa fall kan du vilja dela ett digitalt objekt som består av exempelvis både data och programvara eller en annan kombination av flera resurstyper. I dessa fall finns det två möjliga lösningar:
+
+1. **Välj en typ** – Välj den resurstyp som du anser bäst beskriver och/eller är mest betydelsefull för uppladdningen. Till exempel kan datasetet vara huvudbidraget, medan programvaran endast består av några bearbetningsskript.
+2. **Dela upp uppladdningen** – Dela upp uppladdningen i flera inlägg, ett per resurstyp. Använd denna metod när både datasetet och programvaran är betydande bidrag i sig själva.

--- a/docs/sv/deposit/describe_records.md
+++ b/docs/sv/deposit/describe_records.md
@@ -4,8 +4,8 @@ Se [Skapa ny uppladdning](./create_new_upload.md) för en översikt av att skapa
 
 - **[Resurstyper](#resurstyper)** — Välj rätt resurstyp.
 - **[Digital Object Identifier (DOI)](#digital-object-identifier-doi)** — Hur man reserverar en DOI för inkludering i filer före publicering.
-- **Titlar** — Hur man lägger till huvudtitel och ytterligare titlar.
-- **Publiceringsdatum** — Lär dig använda datumintervall eller oprecisa datum.
+- **[Titlar](#titlar)** — Hur man lägger till huvudtitel och ytterligare titlar.
+- **[Publiceringsdatum](#publiceringsdatum)** — Lär dig använda datumintervall eller oprecisa datum.
 - **Skapare** — Lär dig hur man lägger till skapare/författare för ditt inlägg.
 - **Beskrivningar** — Lär dig hur man lägger till sammanfattningar och anteckningar.
 - **Licenser och rättigheter** — Lär dig välja en licens för ditt inlägg.
@@ -52,3 +52,30 @@ Om du redan har delat eller laddat upp ditt inlägg i en annan databas eller tid
 
 1. I fältet **Digital Object Identifier**, svara **"Ja"** på frågan *"Har du redan en DOI för denna uppladdning?"*
 2. Kopiera och klistra in (för att undvika skrivfel) den befintliga DOI:n i fältet. DOI:n kommer att valideras för korrekt format, och en given DOI kan endast registreras en gång i KTH Data Repository (dubbleringar upptäcks automatiskt).
+
+## Titlar
+
+Titel-fältet är ett obligatoriskt fält i formuläret för uppladdning. Titeln är viktig för att läsare ska kunna hitta din forskning och används i citeringar samt vid visning av inlägg i lagringsplatsen.
+
+Du kan valfritt lägga till ytterligare titlar, såsom undertitlar, översatta titlar eller alternativa titlar.
+
+## Lägg till en ytterligare titel
+
+1. Klicka på knappen **Lägg till titlar**.
+2. Ange den ytterligare titeln och välj titeltypen (*alternativ titel, undertitel, översatt titel eller annan*).
+3. Valfritt: Ange språket för den ytterligare titeln.
+
+## Publiceringsdatum
+
+Fältet **publiceringsdatum** är ett obligatoriskt fält. Som standard är det inställt på det datum då utkastet skapades. Om din uppladdning tidigare publicerats någon annanstans (t.ex. som en tidskriftsartikel), använd datumet för den första publiceringen.
+
+Observera att förutom publiceringsdatumet, håller KTH Data Repository reda på datumet då ett inlägg laddades upp till databasen.
+
+## Oprecisa datum (EDTF)
+
+För äldre innehåll kanske du inte alltid vet det exakta publiceringsdatumet. I dessa fall kan du använda både oprecisa datum och datumintervall enligt **Extended Date Time Format (EDTF) Level 1**-standarden:
+
+1. **Minskad precision för år och månad** – `2025-09` avser månaden september 2025.
+2. **Minskad precision för år** – `2025` avser kalenderåret 2025.
+3. **Tidsintervall** – `2025-01-01/2025-09-23` avser tidsintervallet som börjar den 1 januari 2025 och slutar den 23 september 2025.
+4. **Oprecist tidsintervall** – `1939/1945` avser tidsintervallet som börjar någon gång 1939 och slutar någon gång 1945.

--- a/docs/sv/index.md
+++ b/docs/sv/index.md
@@ -14,7 +14,7 @@
 
     - [Om poster](deposit/about_records.md)
     - [Skapa ny uppladdning](deposit/create_new_upload.md)
-    - [Beskriv poster (WIP)](#)
+    - [Beskriv poster](deposit/describe_records.md)
     - [Hantera filer (WIP)](#)
     - [Restricted records](deposit/restrict_record_access.md)
     - [Share Record Access](deposit/share_record_access.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ plugins:
                 - Om poster: deposit/about_records.md
                 - Skapa ny uppladdning: deposit/create_new_upload.md
                 - Begränsade Poster: deposit/restrict_record_access.md
+                - Beskriv Poster: deposit/describe_records.md
                 - Dela poståtkomst: deposit/share_record_access.md
                 - Github Integration: deposit/github_integration.md
                 - REST API: deposit/rest_api.md
@@ -119,6 +120,7 @@ nav:
       - About Records: deposit/about_records.md
       - Create New Upload: deposit/create_new_upload.md
       - Restricted Records: deposit/restrict_record_access.md
+      - Describe Records: deposit/describe_records.md
       - Share Record Access: deposit/share_record_access.md
       - Github Integration: deposit/github_integration.md
       - REST API: deposit/rest_api.md


### PR DESCRIPTION
Introduce a new page for describing records, including sections on resource types, Digital Object Identifier (DOI), titles, and publication dates. Update navigation to include these new resources.