### PR TITLE
Fix mkdocs dependency issues and update serve command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,6 @@ install:
 	uv sync
 
 serve:
-	uv run mkdocs serve --livereload
+# see: https://github.com/ultrabug/mkdocs-static-i18n/issues/342
+# see: https://github.com/inveniosoftware/docs-invenio-rdm/issues/915
+	NO_MKDOCS_2_WARNING=1 uv run mkdocs serve --livereload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "KTH Data Repository documentation"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mkdocs>=1.6.1",
+    "mkdocs<2.0.0",
     "mkdocs-glightbox>=0.5.2",
     "mkdocs-material>=9.6.22",
     "mkdocs-static-i18n>=1.2.3",

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,2 +1,0 @@
-mkdocs-material>=9.5.38
-mkdocs-static-i18n>=1.2.3


### PR DESCRIPTION
## Description

* Pin mkdocs to a version below 2.0.0 to prevent compatibility issues
* update the serve command to suppress warnings related to mkdocs version 2, 
* remove unnecessary requirements for mkdocs dependencies.